### PR TITLE
[feat] product crud api

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,11 +26,20 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+
+
+    implementation 'org.mapstruct:mapstruct:1.6.3'
+    annotationProcessor 'org.mapstruct:mapstruct-processor:1.6.3'
+
+
     compileOnly 'org.projectlombok:lombok'
+
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'org.postgresql:postgresql'
+
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
     annotationProcessor 'org.projectlombok:lombok'
+    
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,7 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
     implementation("org.springframework.kafka:spring-kafka:3.3.4")
+    testImplementation 'org.springframework.kafka:spring-kafka-test'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,8 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    implementation("org.springframework.kafka:spring-kafka:3.3.4")
 }
 
 tasks.named('test') {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,37 @@
+version: '3.8'
+
+services:
+  kafka:
+    image: bitnami/kafka:3.6
+    container_name: kafka
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_CFG_NODE_ID: 0
+      KAFKA_CFG_PROCESS_ROLES: broker,controller
+      KAFKA_CFG_CONTROLLER_QUORUM_VOTERS: 0@localhost:9093
+      KAFKA_CFG_LISTENERS: PLAINTEXT://:9092,CONTROLLER://:9093
+      KAFKA_CFG_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
+      KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT
+      KAFKA_CFG_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE: "true"
+      KAFKA_KRAFT_CLUSTER_ID: "my-cluster-id"
+    volumes:
+      - kafka-data:/bitnami/kafka
+
+  postgres:
+    container_name: postgresql-store
+    image: postgres:14
+    restart: always
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_USER: product
+      POSTGRES_PASSWORD: product
+      POSTGRES_DB: product
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+
+volumes:
+  kafka-data:
+  postgres-data:

--- a/src/main/java/com/baedal/product/adapter/in/consumer/ProductEventConsumer.java
+++ b/src/main/java/com/baedal/product/adapter/in/consumer/ProductEventConsumer.java
@@ -22,6 +22,7 @@ public class ProductEventConsumer {
     @KafkaListener(topics = "product-save-request", groupId = "product-group")
     public void consume(ConsumerRecord<String, String> record) {
         String payload = record.value();
+        log.info("Kafka 메시지 수신됨: {}", payload);
         String correlationId = new String(record.headers().lastHeader("correlation-id").value());
         String replyTo = new String(record.headers().lastHeader("reply-to").value());
 

--- a/src/main/java/com/baedal/product/adapter/in/consumer/ProductEventConsumer.java
+++ b/src/main/java/com/baedal/product/adapter/in/consumer/ProductEventConsumer.java
@@ -1,0 +1,33 @@
+package com.baedal.product.adapter.in.consumer;
+
+import com.baedal.product.adapter.out.ProductSaveReplyProducer;
+import com.baedal.product.application.port.in.command.ProductCommand;
+import com.baedal.product.application.port.in.command.ProductUseCase;
+import com.baedal.product.application.service.ProductService;
+import com.baedal.product.common.utill.JsonUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ProductEventConsumer {
+
+    private final ProductUseCase productUseCase;         // ✅ 서비스 말고 유즈케이스에 의존!
+    private final ProductSaveReplyProducer replyProducer;
+
+    @KafkaListener(topics = "product-save-request", groupId = "product-group")
+    public void consume(ConsumerRecord<String, String> record) {
+        String payload = record.value();
+        String correlationId = new String(record.headers().lastHeader("correlation-id").value());
+        String replyTo = new String(record.headers().lastHeader("reply-to").value());
+
+        ProductCommand.Request request = JsonUtil.fromJson(payload, ProductCommand.Request.class);
+        ProductCommand.Response response = productUseCase.save(request);   // ✅ 인터페이스 기반 호출
+
+        replyProducer.sendResponse(replyTo, correlationId, response);
+    }
+}

--- a/src/main/java/com/baedal/product/adapter/in/consumer/ProductEventConsumer.java
+++ b/src/main/java/com/baedal/product/adapter/in/consumer/ProductEventConsumer.java
@@ -16,7 +16,7 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class ProductEventConsumer {
 
-    private final ProductUseCase productUseCase;         // ✅ 서비스 말고 유즈케이스에 의존!
+    private final ProductUseCase productUseCase;
     private final ProductSaveReplyProducer replyProducer;
 
     @KafkaListener(topics = "product-save-request", groupId = "product-group")
@@ -26,7 +26,7 @@ public class ProductEventConsumer {
         String replyTo = new String(record.headers().lastHeader("reply-to").value());
 
         ProductCommand.Request request = JsonUtil.fromJson(payload, ProductCommand.Request.class);
-        ProductCommand.Response response = productUseCase.save(request);   // ✅ 인터페이스 기반 호출
+        ProductCommand.Response response = productUseCase.save(request);
 
         replyProducer.sendResponse(replyTo, correlationId, response);
     }

--- a/src/main/java/com/baedal/product/adapter/in/web/controller/ProductController.java
+++ b/src/main/java/com/baedal/product/adapter/in/web/controller/ProductController.java
@@ -1,0 +1,28 @@
+package com.baedal.product.adapter.in.web.controller;
+
+import com.baedal.product.adapter.in.web.request.ProductReq;
+import com.baedal.product.adapter.in.web.response.ProductRes;
+
+import com.baedal.product.application.mapper.ProductMapper;
+import com.baedal.product.application.port.in.command.ProductCommand;
+import com.baedal.product.application.port.in.command.ProductUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/products")
+@RequiredArgsConstructor
+public class ProductController {
+
+    private final ProductMapper mapper;
+    private final ProductUseCase productUseCase;
+
+    @PostMapping("/create")
+    public ProductRes createProduct(@RequestBody ProductReq request) {
+        ProductCommand.Request command = mapper.toCommand(request);
+        ProductCommand.Response response = productUseCase.createProduct(command);
+
+        return mapper.toResponse(response);
+    }
+}

--- a/src/main/java/com/baedal/product/adapter/in/web/controller/ProductController.java
+++ b/src/main/java/com/baedal/product/adapter/in/web/controller/ProductController.java
@@ -22,19 +22,15 @@ public class ProductController {
     private final ProductUseCase productUseCase;
 
     @PostMapping("/create")
-    public ProductRes createProduct(@RequestBody ProductReq request) {
-        ProductCommand.Request command = productMapper.toCommand(request);
-        ProductCommand.Response response = productUseCase.createProduct(command);
-
-        return productMapper.toResponse(response);
+    public ResponseEntity<ProductCommand.Response> createProduct(@RequestBody ProductReq request) {
+        ProductCommand.Request command = productMapper.toCommand(request); // 🔁
+        ProductCommand.Response response = productUseCase.createProduct(command); // 🔁
+        return ResponseEntity.ok(response);
     }
 
     @GetMapping
-    public ResponseEntity<List<ProductRes>> getProductsByStoreId(@RequestParam Long storeId) {
+    public ResponseEntity<List<ProductCommand.Response>> getProductsByStoreId(@RequestParam Long storeId) {
         List<ProductCommand.Response> responses = productUseCase.getProductsByStoreId(storeId);
-        List<ProductRes> productResList = responses.stream()
-                .map(productMapper::toResponse)
-                .toList();
-        return ResponseEntity.ok(productResList);
+        return ResponseEntity.ok(responses);
     }
 }

--- a/src/main/java/com/baedal/product/adapter/in/web/controller/ProductController.java
+++ b/src/main/java/com/baedal/product/adapter/in/web/controller/ProductController.java
@@ -6,23 +6,35 @@ import com.baedal.product.adapter.in.web.response.ProductRes;
 import com.baedal.product.application.mapper.ProductMapper;
 import com.baedal.product.application.port.in.command.ProductCommand;
 import com.baedal.product.application.port.in.command.ProductUseCase;
+import com.baedal.product.domain.model.Product;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/products")
 @RequiredArgsConstructor
 public class ProductController {
 
-    private final ProductMapper mapper;
+    private final ProductMapper productMapper;
     private final ProductUseCase productUseCase;
 
     @PostMapping("/create")
     public ProductRes createProduct(@RequestBody ProductReq request) {
-        ProductCommand.Request command = mapper.toCommand(request);
+        ProductCommand.Request command = productMapper.toCommand(request);
         ProductCommand.Response response = productUseCase.createProduct(command);
 
-        return mapper.toResponse(response);
+        return productMapper.toResponse(response);
+    }
+
+    @GetMapping
+    public ResponseEntity<List<ProductRes>> getProductsByStoreId(@RequestParam Long storeId) {
+        List<ProductCommand.Response> responses = productUseCase.getProductsByStoreId(storeId);
+        List<ProductRes> productResList = responses.stream()
+                .map(productMapper::toResponse)
+                .toList();
+        return ResponseEntity.ok(productResList);
     }
 }

--- a/src/main/java/com/baedal/product/adapter/in/web/request/ProductReq.java
+++ b/src/main/java/com/baedal/product/adapter/in/web/request/ProductReq.java
@@ -1,0 +1,11 @@
+package com.baedal.product.adapter.in.web.request;
+
+public class ProductReq {
+    private Long storeId;
+    private String category;
+    private String name;
+    private int price;
+    private String productPictureUrl;
+    private boolean popularity;
+    private String status;
+}

--- a/src/main/java/com/baedal/product/adapter/in/web/response/ProductRes.java
+++ b/src/main/java/com/baedal/product/adapter/in/web/response/ProductRes.java
@@ -1,0 +1,17 @@
+package com.baedal.product.adapter.in.web.response;
+
+import java.sql.Timestamp;
+
+public class ProductRes {
+    private Long productId;
+    private Long storeId;
+    private String category;
+    private String name;
+    private int price;
+    private String productPictureUrl;
+    private boolean popularity;
+    private Timestamp createdDate;
+    private Timestamp modifiedDate;
+    private String status;
+
+}

--- a/src/main/java/com/baedal/product/adapter/out/ProductEventProducer.java
+++ b/src/main/java/com/baedal/product/adapter/out/ProductEventProducer.java
@@ -1,0 +1,4 @@
+package com.baedal.product.adapter.out;
+
+public class ProductEventProducer {
+}

--- a/src/main/java/com/baedal/product/adapter/out/ProductPersistenceAdapter.java
+++ b/src/main/java/com/baedal/product/adapter/out/ProductPersistenceAdapter.java
@@ -1,0 +1,38 @@
+package com.baedal.product.adapter.out;
+
+import com.baedal.product.adapter.out.persistence.repository.ProductRepository;
+import com.baedal.product.application.mapper.ProductMapper;
+import com.baedal.product.application.port.out.ProductRepositoryPort;
+import com.baedal.product.domain.model.Product;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Component
+public class ProductPersistenceAdapter implements ProductRepositoryPort {
+
+    private final ProductRepository productRepository;
+    private final ProductMapper productMapper;
+
+    public Optional<Product> findById(Long productId) {
+        return Optional.empty();
+    }
+
+    @Override
+    public List<Product> findAll() {
+        return List.of();
+    }
+
+    @Override
+    public Product save(Product product) {
+        return null;
+    }
+
+    @Override
+    public void deleteById(Long productId) {
+
+    }
+}

--- a/src/main/java/com/baedal/product/adapter/out/ProductPersistenceAdapter.java
+++ b/src/main/java/com/baedal/product/adapter/out/ProductPersistenceAdapter.java
@@ -1,5 +1,7 @@
 package com.baedal.product.adapter.out;
 
+import com.baedal.product.adapter.out.persistence.entity.ProductEntity;
+import com.baedal.product.adapter.out.persistence.mapper.ProductPersistenceMapper;
 import com.baedal.product.adapter.out.persistence.repository.ProductRepository;
 import com.baedal.product.application.mapper.ProductMapper;
 import com.baedal.product.application.port.out.ProductRepositoryPort;
@@ -15,7 +17,7 @@ import java.util.Optional;
 public class ProductPersistenceAdapter implements ProductRepositoryPort {
 
     private final ProductRepository productRepository;
-    private final ProductMapper productMapper;
+    private final ProductPersistenceMapper productPersistenceMapper;
 
     public Optional<Product> findById(Long productId) {
         return Optional.empty();
@@ -34,5 +36,12 @@ public class ProductPersistenceAdapter implements ProductRepositoryPort {
     @Override
     public void deleteById(Long productId) {
 
+    }
+
+    @Override
+    public List<Product> findByStoreId(Long storeId) {
+        return productRepository.findByStoreId(storeId).stream()
+                .map(productPersistenceMapper::entityToDomain)
+                .toList();
     }
 }

--- a/src/main/java/com/baedal/product/adapter/out/ProductPersistenceAdapter.java
+++ b/src/main/java/com/baedal/product/adapter/out/ProductPersistenceAdapter.java
@@ -19,23 +19,27 @@ public class ProductPersistenceAdapter implements ProductRepositoryPort {
     private final ProductRepository productRepository;
     private final ProductPersistenceMapper productPersistenceMapper;
 
+    @Override
     public Optional<Product> findById(Long productId) {
+        // TODO: productId로 ProductEntity를 조회하고, entityToDomain 변환 후 Optional로 감싸서 반환
         return Optional.empty();
     }
 
     @Override
     public List<Product> findAll() {
+        // TODO: 모든 ProductEntity를 조회하고, entityToDomain으로 변환 후 리스트 반환
         return List.of();
     }
 
     @Override
     public Product save(Product product) {
+        // TODO: Domain 객체를 entity로 변환한 뒤, 저장하고 다시 domain으로 변환하여 반환
         return null;
     }
 
     @Override
     public void deleteById(Long productId) {
-
+        // TODO: productId로 ProductEntity를 삭제
     }
 
     @Override

--- a/src/main/java/com/baedal/product/adapter/out/ProductSaveReplyProducer.java
+++ b/src/main/java/com/baedal/product/adapter/out/ProductSaveReplyProducer.java
@@ -1,0 +1,22 @@
+package com.baedal.product.adapter.out;
+
+import com.baedal.product.application.port.in.command.ProductCommand;
+import com.baedal.product.common.utill.JsonUtil;
+import lombok.RequiredArgsConstructor;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ProductSaveReplyProducer {
+
+    private final KafkaTemplate<String, String> kafkaTemplate;
+
+    public void sendResponse(String topic, String correlationId, ProductCommand.Response response) {
+        String json = JsonUtil.toJson(response);
+        ProducerRecord<String, String> record = new ProducerRecord<>(topic, json);
+        record.headers().add("correlation-id", correlationId.getBytes());
+        kafkaTemplate.send(record);
+    }
+}

--- a/src/main/java/com/baedal/product/adapter/out/persistence/entity/ProductEntity.java
+++ b/src/main/java/com/baedal/product/adapter/out/persistence/entity/ProductEntity.java
@@ -6,7 +6,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import lombok.Getter;
 
-@Entity
+
 @Getter
 public class ProductEntity {
     @Id

--- a/src/main/java/com/baedal/product/adapter/out/persistence/entity/ProductEntity.java
+++ b/src/main/java/com/baedal/product/adapter/out/persistence/entity/ProductEntity.java
@@ -1,0 +1,22 @@
+package com.baedal.product.adapter.out.persistence.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.Getter;
+
+@Entity
+@Getter
+public class ProductEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long productId;
+
+    private Long storeId;
+    private String category;
+    private String name;
+    private int price;
+    private String productPictureUrl;
+
+}

--- a/src/main/java/com/baedal/product/adapter/out/persistence/mapper/ProductPersistenceMapper.java
+++ b/src/main/java/com/baedal/product/adapter/out/persistence/mapper/ProductPersistenceMapper.java
@@ -4,6 +4,7 @@ import com.baedal.product.adapter.in.web.response.ProductRes;
 import com.baedal.product.adapter.out.persistence.entity.ProductEntity;
 import com.baedal.product.domain.model.Product;
 import org.mapstruct.Mapper;
+import org.springframework.stereotype.Component;
 
 @Mapper(componentModel = "spring")
 public interface ProductPersistenceMapper {

--- a/src/main/java/com/baedal/product/adapter/out/persistence/mapper/ProductPersistenceMapper.java
+++ b/src/main/java/com/baedal/product/adapter/out/persistence/mapper/ProductPersistenceMapper.java
@@ -1,0 +1,16 @@
+package com.baedal.product.adapter.out.persistence.mapper;
+
+import com.baedal.product.adapter.in.web.response.ProductRes;
+import com.baedal.product.adapter.out.persistence.entity.ProductEntity;
+import com.baedal.product.domain.model.Product;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface ProductPersistenceMapper {
+
+    // Entity -> Domain 변환
+    Product entityToDomain(ProductEntity productEntity);
+
+    // Domain -> Entity 변환
+    ProductEntity domainToEntity(Product product);
+}

--- a/src/main/java/com/baedal/product/adapter/out/persistence/repository/ProductRepository.java
+++ b/src/main/java/com/baedal/product/adapter/out/persistence/repository/ProductRepository.java
@@ -1,0 +1,12 @@
+package com.baedal.product.adapter.out.persistence.repository;
+
+import com.baedal.product.domain.model.Product;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+// Product 엔티티가 있다고 가정
+@Repository
+public interface ProductRepository extends JpaRepository<Product, Long> {
+    // 필요한 경우 커스텀 메서드 추가 가능
+    Product findByName(String name);
+}

--- a/src/main/java/com/baedal/product/adapter/out/persistence/repository/ProductRepository.java
+++ b/src/main/java/com/baedal/product/adapter/out/persistence/repository/ProductRepository.java
@@ -1,12 +1,16 @@
 package com.baedal.product.adapter.out.persistence.repository;
 
+import com.baedal.product.adapter.out.persistence.entity.ProductEntity;
 import com.baedal.product.domain.model.Product;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 // Product 엔티티가 있다고 가정
 @Repository
 public interface ProductRepository extends JpaRepository<Product, Long> {
     // 필요한 경우 커스텀 메서드 추가 가능
     Product findByName(String name);
+    List<ProductEntity> findByStoreId(Long storeId);
 }

--- a/src/main/java/com/baedal/product/adapter/out/persistence/repository/ProductRepository.java
+++ b/src/main/java/com/baedal/product/adapter/out/persistence/repository/ProductRepository.java
@@ -7,7 +7,6 @@ import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
-// Product 엔티티가 있다고 가정
 @Repository
 public interface ProductRepository extends JpaRepository<Product, Long> {
     // 필요한 경우 커스텀 메서드 추가 가능

--- a/src/main/java/com/baedal/product/application/mapper/ProductMapper.java
+++ b/src/main/java/com/baedal/product/application/mapper/ProductMapper.java
@@ -5,13 +5,17 @@ import com.baedal.product.adapter.in.web.request.ProductReq;
 import com.baedal.product.adapter.in.web.response.ProductRes;
 import com.baedal.product.application.port.in.command.ProductCommand;
 
+import com.baedal.product.domain.model.Product;
 import org.mapstruct.Mapper;
+
+import java.util.List;
 
 
 @Mapper(componentModel = "spring")
 public interface ProductMapper {
 
     ProductCommand.Request toCommand(ProductReq request);
-
-    ProductRes toResponse(ProductCommand.Response response);
+    Product toDomain(ProductCommand.Request request);
+    ProductCommand.Response toResponse(Product product);
+    List<ProductCommand.Response> toResponseList(List<Product> products);
 }

--- a/src/main/java/com/baedal/product/application/mapper/ProductMapper.java
+++ b/src/main/java/com/baedal/product/application/mapper/ProductMapper.java
@@ -1,0 +1,17 @@
+package com.baedal.product.application.mapper;
+
+
+import com.baedal.product.adapter.in.web.request.ProductReq;
+import com.baedal.product.adapter.in.web.response.ProductRes;
+import com.baedal.product.application.port.in.command.ProductCommand;
+
+import org.mapstruct.Mapper;
+
+
+@Mapper(componentModel = "spring")
+public interface ProductMapper {
+
+    ProductCommand.Request toCommand(ProductReq request);
+
+    ProductRes toResponse(ProductCommand.Response response);
+}

--- a/src/main/java/com/baedal/product/application/port/in/command/ProductCommand.java
+++ b/src/main/java/com/baedal/product/application/port/in/command/ProductCommand.java
@@ -22,5 +22,7 @@ public class ProductCommand {
         private String name;
         private String category;
         private int price;
+        private Long storeId;
+        private String productPictureUrl;
     }
 }

--- a/src/main/java/com/baedal/product/application/port/in/command/ProductCommand.java
+++ b/src/main/java/com/baedal/product/application/port/in/command/ProductCommand.java
@@ -1,0 +1,26 @@
+package com.baedal.product.application.port.in.command;
+
+import lombok.Builder;
+import lombok.Getter;
+
+public class ProductCommand {
+
+    @Getter
+    @Builder
+    public static class Request {
+        private String name;
+        private String category;
+        private int price;
+        private String productPictureUrl;
+        private Long storeId;
+    }
+
+    @Getter
+    @Builder
+    public static class Response {
+        private Long productId;
+        private String name;
+        private String category;
+        private int price;
+    }
+}

--- a/src/main/java/com/baedal/product/application/port/in/command/ProductCommand.java
+++ b/src/main/java/com/baedal/product/application/port/in/command/ProductCommand.java
@@ -1,12 +1,13 @@
 package com.baedal.product.application.port.in.command;
 
-import lombok.Builder;
-import lombok.Getter;
+import lombok.*;
 
 public class ProductCommand {
 
     @Getter
     @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
     public static class Request {
         private String name;
         private String category;
@@ -17,6 +18,8 @@ public class ProductCommand {
 
     @Getter
     @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
     public static class Response {
         private Long productId;
         private String name;

--- a/src/main/java/com/baedal/product/application/port/in/command/ProductUseCase.java
+++ b/src/main/java/com/baedal/product/application/port/in/command/ProductUseCase.java
@@ -8,4 +8,5 @@ public interface ProductUseCase {
     ProductCommand.Response createProduct(ProductCommand.Request productCommand);
     Product getProduct(Long productId);
     List<ProductCommand.Response> getProductsByStoreId(Long storeId);
+    ProductCommand.Response save(ProductCommand.Request request);
 }

--- a/src/main/java/com/baedal/product/application/port/in/command/ProductUseCase.java
+++ b/src/main/java/com/baedal/product/application/port/in/command/ProductUseCase.java
@@ -2,7 +2,10 @@ package com.baedal.product.application.port.in.command;
 
 import com.baedal.product.domain.model.Product;
 
+import java.util.List;
+
 public interface ProductUseCase {
     ProductCommand.Response createProduct(ProductCommand.Request productCommand);
     Product getProduct(Long productId);
+    List<ProductCommand.Response> getProductsByStoreId(Long storeId);
 }

--- a/src/main/java/com/baedal/product/application/port/in/command/ProductUseCase.java
+++ b/src/main/java/com/baedal/product/application/port/in/command/ProductUseCase.java
@@ -1,0 +1,8 @@
+package com.baedal.product.application.port.in.command;
+
+import com.baedal.product.domain.model.Product;
+
+public interface ProductUseCase {
+    ProductCommand.Response createProduct(ProductCommand.Request productCommand);
+    Product getProduct(Long productId);
+}

--- a/src/main/java/com/baedal/product/application/port/out/ProductRepositoryPort.java
+++ b/src/main/java/com/baedal/product/application/port/out/ProductRepositoryPort.java
@@ -10,4 +10,5 @@ public interface ProductRepositoryPort {
     List<Product> findAll();
     Product save(Product product);
     void deleteById(Long productId);
+    List<Product> findByStoreId(Long storeId);
 }

--- a/src/main/java/com/baedal/product/application/port/out/ProductRepositoryPort.java
+++ b/src/main/java/com/baedal/product/application/port/out/ProductRepositoryPort.java
@@ -1,0 +1,13 @@
+package com.baedal.product.application.port.out;
+
+import com.baedal.product.domain.model.Product;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ProductRepositoryPort {
+    Optional<Product> findById(Long productId);
+    List<Product> findAll();
+    Product save(Product product);
+    void deleteById(Long productId);
+}

--- a/src/main/java/com/baedal/product/application/service/ProductService.java
+++ b/src/main/java/com/baedal/product/application/service/ProductService.java
@@ -1,0 +1,46 @@
+package com.baedal.product.application.service;
+
+import com.baedal.product.application.port.in.command.ProductCommand;
+import com.baedal.product.application.port.in.command.ProductUseCase;
+import com.baedal.product.application.port.out.ProductRepositoryPort;
+import com.baedal.product.domain.model.Product;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class ProductService implements ProductUseCase {
+
+    private final ProductRepositoryPort repositoryPort;
+
+
+    @Override
+    @Transactional
+    public ProductCommand.Response createProduct(ProductCommand.Request req) {
+        // Command -> Domain
+        Product product = Product.builder()
+                .name(req.getName())
+                .category(req.getCategory())
+                .price(req.getPrice())
+                .productPictureUrl(req.getProductPictureUrl())
+                .storeId(req.getStoreId())
+                .build();
+
+        Product savedProduct = repositoryPort.save(product);
+
+        // Domain -> Response
+        return ProductCommand.Response.builder()
+                .productId(savedProduct.getProductId())
+                .name(savedProduct.getName())
+                .category(savedProduct.getCategory())
+                .price(savedProduct.getPrice())
+                .build();
+    }
+
+    @Override
+    public Product getProduct(Long productId) {
+        return null;
+    }
+
+}

--- a/src/main/java/com/baedal/product/application/service/ProductService.java
+++ b/src/main/java/com/baedal/product/application/service/ProductService.java
@@ -1,5 +1,6 @@
 package com.baedal.product.application.service;
 
+import com.baedal.product.application.mapper.ProductMapper;
 import com.baedal.product.application.port.in.command.ProductCommand;
 import com.baedal.product.application.port.in.command.ProductUseCase;
 import com.baedal.product.application.port.out.ProductRepositoryPort;
@@ -15,7 +16,7 @@ import java.util.List;
 public class ProductService implements ProductUseCase {
 
     private final ProductRepositoryPort repositoryPort;
-
+    private final ProductMapper productMapper;
 
     @Override
     @Transactional
@@ -48,15 +49,13 @@ public class ProductService implements ProductUseCase {
     public List<ProductCommand.Response> getProductsByStoreId(Long storeId) {
         List<Product> products = repositoryPort.findByStoreId(storeId);
         return products.stream()
-                .map(product -> ProductCommand.Response.builder()
-                        .productId(product.getProductId())
-                        .storeId(product.getStoreId())
-                        .name(product.getName())
-                        .category(product.getCategory())
-                        .price(product.getPrice())
-                        .productPictureUrl(product.getProductPictureUrl())
-                        .build())
+                .map(productMapper::toResponse) // ✅ 매퍼 사용
                 .toList();
+    }
+    public ProductCommand.Response save(ProductCommand.Request req) {
+        Product product = productMapper.toDomain(req);
+        Product saved = repositoryPort.save(product);
+        return productMapper.toResponse(saved);
     }
 
 }

--- a/src/main/java/com/baedal/product/application/service/ProductService.java
+++ b/src/main/java/com/baedal/product/application/service/ProductService.java
@@ -6,6 +6,7 @@ import com.baedal.product.application.port.in.command.ProductUseCase;
 import com.baedal.product.application.port.out.ProductRepositoryPort;
 import com.baedal.product.domain.model.Product;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -13,6 +14,7 @@ import java.util.List;
 
 @RequiredArgsConstructor
 @Service
+@Slf4j
 public class ProductService implements ProductUseCase {
 
     private final ProductRepositoryPort repositoryPort;
@@ -30,7 +32,9 @@ public class ProductService implements ProductUseCase {
                 .storeId(req.getStoreId())
                 .build();
 
+        log.info("Saving product: {}", product);
         Product savedProduct = repositoryPort.save(product);
+        log.info("Saved product: {}", savedProduct);
 
         // Domain -> Response
         return ProductCommand.Response.builder()

--- a/src/main/java/com/baedal/product/application/service/ProductService.java
+++ b/src/main/java/com/baedal/product/application/service/ProductService.java
@@ -8,6 +8,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @RequiredArgsConstructor
 @Service
 public class ProductService implements ProductUseCase {
@@ -41,6 +43,20 @@ public class ProductService implements ProductUseCase {
     @Override
     public Product getProduct(Long productId) {
         return null;
+    }
+    @Override
+    public List<ProductCommand.Response> getProductsByStoreId(Long storeId) {
+        List<Product> products = repositoryPort.findByStoreId(storeId);
+        return products.stream()
+                .map(product -> ProductCommand.Response.builder()
+                        .productId(product.getProductId())
+                        .storeId(product.getStoreId())
+                        .name(product.getName())
+                        .category(product.getCategory())
+                        .price(product.getPrice())
+                        .productPictureUrl(product.getProductPictureUrl())
+                        .build())
+                .toList();
     }
 
 }

--- a/src/main/java/com/baedal/product/common/utill/JsonUtil.java
+++ b/src/main/java/com/baedal/product/common/utill/JsonUtil.java
@@ -1,0 +1,25 @@
+package com.baedal.product.common.utill;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class JsonUtil {
+
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    public static <T> T fromJson(String json, Class<T> clazz) {
+        try {
+            return mapper.readValue(json, clazz);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("JSON 파싱 실패", e);
+        }
+    }
+
+    public static String toJson(Object obj) {
+        try {
+            return mapper.writeValueAsString(obj);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("JSON 직렬화 실패", e);
+        }
+    }
+}

--- a/src/main/java/com/baedal/product/config/KafkaConfig.java
+++ b/src/main/java/com/baedal/product/config/KafkaConfig.java
@@ -1,14 +1,20 @@
 package com.baedal.product.config;
 
 import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
-import org.springframework.kafka.core.ConsumerFactory;
-import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.core.*;
+import org.springframework.kafka.listener.ContainerProperties;
+import org.springframework.kafka.listener.KafkaMessageListenerContainer;
+import org.springframework.kafka.requestreply.ReplyingKafkaTemplate;
 import org.springframework.kafka.support.serializer.JsonDeserializer;
+
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -16,23 +22,45 @@ import java.util.Map;
 @Configuration
 public class KafkaConfig {
 
-    @Value("${spring.kafka.producer.bootstrap-servers}")
-    private String bootstrapServers;
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapAddress;
 
     @Bean
-    public ConsumerFactory<String, Object> consumerFactory() {
-        Map<String, Object> properties = new HashMap<>();
-        properties.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
-        properties.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-        properties.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
-        return new DefaultKafkaConsumerFactory<>(properties);
+    public ProducerFactory<String, String> producerFactory(){
+        Map<String, Object> props = new HashMap<>();
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapAddress);
+        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        return new DefaultKafkaProducerFactory<>(props);
     }
 
     @Bean
-    public ConcurrentKafkaListenerContainerFactory<String, Object> kafkaListenerContainerFactory() {
-        ConcurrentKafkaListenerContainerFactory<String, Object> factory =
-                new ConcurrentKafkaListenerContainerFactory<>();
-        factory.setConsumerFactory(consumerFactory());
-        return factory;
+    public ConsumerFactory<String, String> consumerFactory() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapAddress);
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, "product-consumer-group");
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        return new DefaultKafkaConsumerFactory<>(props);
+    }
+
+    @Bean
+    public KafkaTemplate<String, String> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+
+    // 응답 컨테이너: Reply를 받을 토픽
+    @Bean
+    public KafkaMessageListenerContainer<String, String> replyContainer() {
+        ContainerProperties containerProps = new ContainerProperties("product-save-reply");
+        return new KafkaMessageListenerContainer<>(consumerFactory(), containerProps);
+    }
+
+    @Bean
+    public ReplyingKafkaTemplate<String, String, String> replyingKafkaTemplate() {
+        ReplyingKafkaTemplate<String, String, String> template =
+                new ReplyingKafkaTemplate<>(producerFactory(), replyContainer());
+        template.setDefaultReplyTimeout(Duration.ofSeconds(5));
+        return template;
     }
 }

--- a/src/main/java/com/baedal/product/config/KafkaConfig.java
+++ b/src/main/java/com/baedal/product/config/KafkaConfig.java
@@ -1,0 +1,38 @@
+package com.baedal.product.config;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+import java.util.HashMap;
+import java.util.Map;
+
+
+@Configuration
+public class KafkaConfig {
+
+    @Value("${spring.kafka.producer.bootstrap-servers}")
+    private String bootstrapServers;
+
+    @Bean
+    public ConsumerFactory<String, Object> consumerFactory() {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        properties.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        properties.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+        return new DefaultKafkaConsumerFactory<>(properties);
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, Object> kafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, Object> factory =
+                new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory());
+        return factory;
+    }
+}

--- a/src/main/java/com/baedal/product/domain/model/Product.java
+++ b/src/main/java/com/baedal/product/domain/model/Product.java
@@ -1,0 +1,19 @@
+package com.baedal.product.domain.model;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+
+
+import java.sql.Timestamp;
+
+@Getter
+@Builder
+public class Product {
+    private Long productId;
+    private Long storeId;
+    private String category;
+    private String name;
+    private int price;
+    private String productPictureUrl;
+}

--- a/src/main/java/com/baedal/product/domain/model/Product.java
+++ b/src/main/java/com/baedal/product/domain/model/Product.java
@@ -1,16 +1,20 @@
 package com.baedal.product.domain.model;
 
 import jakarta.persistence.*;
-import lombok.Builder;
-import lombok.Getter;
+import lombok.*;
 
-
-import java.sql.Timestamp;
-
+@Entity
+@Table(name = "product_entity") // 테이블 이름 명시 (선택)
 @Getter
 @Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class Product {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long productId;
+
     private Long storeId;
     private String category;
     private String name;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=product

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,25 +1,27 @@
 spring:
-
   datasource:
     url: jdbc:postgresql://localhost:5432/product
     username: product
     password: product
     driver-class-name: org.postgresql.Driver
 
-
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     properties:
       hibernate:
         show_sql: true
         format_sql: true
 
   kafka:
+    bootstrap-servers: localhost:9092
     consumer:
-      bootstrap-servers: localhost:10000
+      group-id: product-consumer-group
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
     producer:
-      bootstrap-servers: localhost:10000
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
 
 server:
   port: 8084

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -25,3 +25,8 @@ spring:
 
 server:
   port: 8084
+
+logging:
+  level:
+    root: info
+    com.baedal.product: debug

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,25 @@
+spring:
+
+  datasource:
+    url: jdbc:postgresql://localhost:5432/product
+    username: product
+    password: product
+    driver-class-name: org.postgresql.Driver
+
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true
+
+  kafka:
+    consumer:
+      bootstrap-servers: localhost:10000
+    producer:
+      bootstrap-servers: localhost:10000
+
+server:
+  port: 8084

--- a/src/test/java/com/baedal/product/ProductEventConsumerTest.java
+++ b/src/test/java/com/baedal/product/ProductEventConsumerTest.java
@@ -1,0 +1,37 @@
+package com.baedal.product;
+
+import com.baedal.product.application.port.in.command.ProductCommand;
+import com.baedal.product.common.utill.JsonUtil;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+
+@SpringBootTest
+@EmbeddedKafka(partitions = 1, topics = {"product-save-request"}, brokerProperties = {
+        "listeners=PLAINTEXT://localhost:9092", "port=9092"
+})
+public class ProductEventConsumerTest {
+
+    @Autowired
+    private KafkaTemplate<String, String> kafkaTemplate;
+
+    @Test
+    void testConsume() throws Exception {
+        // given
+        ProductCommand.Request request = new ProductCommand.Request("치킨", "한식", 15000, "chicken.jpg", 1L);
+        String payload = JsonUtil.toJson(request);
+
+        ProducerRecord<String, String> record = new ProducerRecord<>("product-save-request", payload);
+        record.headers().add("correlation-id", "1234".getBytes());
+        record.headers().add("reply-to", "product-save-reply".getBytes());
+
+        // when
+        kafkaTemplate.send(record);
+
+        // then
+        // 응답 확인은 ReplyTopic 컨슘하거나 log 찍는 방식으로 확인 가능
+    }
+}


### PR DESCRIPTION
🛠️ PR 제목

feat: storeId 기반 상품 리스트 조회 API 구현

주요 변경 사항
- GET /products?storeId={storeId} API 구현
- ProductController에 storeId 기반 조회 엔드포인트 추가
- ProductUseCase, ProductService, ProductRepositoryPort,ProductPersistenceAdapter 계층 연동
- ProductRepository에 findByStoreId(Long storeId) JPA 메서드 추가
- ProductEntity ↔ Product ↔ ProductCommand.Response ↔ ProductRes 간 MapStruct 매핑 적용


주요 변경 사항
Kafka 설정 및 Docker Compose 추가

- Request-Reply 기반 Kafka 메시지 처리
- Kafka 테스트 작성